### PR TITLE
updated DNA with get_game_hash fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ It might take a few seconds to unlock the keystore but you should see something 
 ```
 Using config path: ./conductor-config.toml
 Unlocking agent keys:
-Unlocking key for agent 'test_agent1': 
+Unlocking key for agent 'test_agent1':
 Reading keystore from ./agent1.keystore
-Unlocking key for agent 'test_agent2': 
+Unlocking key for agent 'test_agent2':
 Reading keystore from ./agent2.keystore
 2019-05-17 15:55:37 ThreadId(1):conductor: starting signal loop
 Reading DNA from ./dist/generic-game.dna.json
@@ -62,7 +62,7 @@ Your agent address is "HcScjcgKqXC5pmfvka9DmtEJwVr548yd86UPtJGGoue9ynuikuRTN7oE5
 Send this to other players so they can invite you to a game.
 
 
-No game> 
+No game>
 ```
 
 
@@ -76,7 +76,7 @@ cargo run http://localhost:3002 instance2
 
 ### 3. Play a game
 
-Now the tricky part, to play a game of tic-tac-toe with yourself! Keep the conductor running and both windows with the CLI. We'll refer to one of them as Agent A and the other as Agent B. 
+Now the tricky part, to play a game of tic-tac-toe with yourself! Keep the conductor running and both windows with the CLI. We'll refer to one of them as Agent A and the other as Agent B.
 
 Agent A will be the one to create the game. Copy the agent address from Agent B and run the following command in **Agent A**:
 ```
@@ -85,7 +85,7 @@ new_game HcScidPSdAT43q9qirJwt5rHJYjjsvougV3jgSBwdJujszw3bBu5Mktr74Rgnea
 
 This should create a new game and show the following output:
 ```
-Non-creator must make the first move 
+Non-creator must make the first move
 
   x  0 1 2
 y
@@ -93,7 +93,7 @@ y
 1   | | | |
 2   | | | |
 
-QmTNHtXZye7vz3d4LQz5zgHvk1wvxbsBHcstorDWQxshfZ> 
+QmTNHtXZye7vz3d4LQz5zgHvk1wvxbsBHcstorDWQxshfZ>
 ```
 
 We have just commit our first entry in the local chain and DHT! A `Game` entry was created with Agent B as the opponent and shared to the DHT. The hash at the bottom of the screen is the hash/address of the Game entry in the DHT. This is the unique identifier we can use to join this game (Note this will be different for everyone as our Game entry includes a timestamp).
@@ -103,12 +103,12 @@ Copy the game address and run the following in **Agent B**
 join_game QmTNHtXZye7vz3d4LQz5zgHvk1wvxbsBHcstorDWQxshfZ
 ```
 
-If the Game entry was successfully shared in the previous step Agent B shoud now see:
+If the Game entry was successfully shared in the previous step Agent B should now see:
 
 ```
 Setting current game hash to QmTNHtXZye7vz3d4LQz5zgHvk1wvxbsBHcstorDWQxshfZ
 
-Non-creator must make the first move 
+Non-creator must make the first move
 
   x  0 1 2
 y
@@ -141,7 +141,7 @@ Move cast successfully
 Waiting for gossip...
 OK!
 
-It is your opponents turn 
+It is your opponents turn
 
   x  0 1 2
 y

--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -4,8 +4,6 @@ file = "./dist/generic-game.dna.json"
 hash = "QmDontCheck"
 
 
-
-
 [[agents]]
 id = "test_agent1"
 name = "HoloTester1"
@@ -17,8 +15,6 @@ id = "test_agent2"
 name = "HoloTester2"
 public_address = "HcScidPSdAT43q9qirJwt5rHJYjjsvougV3jgSBwdJujszw3bBu5Mktr74Rgnea"
 keystore_file = "./agent2.keystore"
-
-
 
 
 [[instances]]
@@ -36,8 +32,6 @@ agent = "test_agent2"
 [instances.storage]
 type = "memory"
 path = "tmp-storage"
-
-
 
 
 [[interfaces]]

--- a/zomes/main/code/src/lib.rs
+++ b/zomes/main/code/src/lib.rs
@@ -18,6 +18,7 @@ use hdk::{
 };
 use hdk::holochain_core_types::{
     cas::content::Address,
+    cas::content::AddressableContent,
     entry::Entry,
 };
 
@@ -96,6 +97,19 @@ pub mod main {
             new_game.into(),
         );
         hdk::commit_entry(&game_entry)
+    }
+
+    #[zome_fn("hc_public")]
+    fn get_game_hash(opponent: Address, timestamp: u32) -> ZomeApiResult<Address> {
+        let new_game = Game {
+            player_1: opponent,
+            player_2: AGENT_ADDRESS.to_string().into(),
+            created_at: timestamp,
+        };
+        Ok(Entry::App(
+            "game".into(),
+            new_game.into(),
+        ).address())
     }
 
     #[zome_fn("hc_public")]


### PR DESCRIPTION
Adds new function that allows the proposal author to generate the same game hash as the player who requested and successfully joined the game  (ie. the game generator), and thereby allow them to join in the same game play.

TL;DR:
 - Adds `get_game_hash`
- New Hash: `QmasydEL51rYG8iGoTmEtyBfetQZ5gySyouzWGmyXqewWr`